### PR TITLE
manabaのシラバスリンク位置直し&ページ限定

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,10 @@
     },
     {
       "js": ["src/content_script_manaba.js"],
-      "matches": ["https://manaba.tsukuba.ac.jp/ct/course_*"]
+      "matches": [
+        "https://manaba.tsukuba.ac.jp/ct/course_*",
+        "https://manaba.tsukuba.ac.jp/ct/page_*"
+      ]
     }
   ],
   "web_accessible_resources": [

--- a/src/content_script_manaba.js
+++ b/src/content_script_manaba.js
@@ -1,11 +1,6 @@
 // Load src/index.js as an ESM
 (async () => {
-  const libJsUrl = chrome.runtime.getURL("src/lib.js");
   const indexManabaJsUrl = chrome.runtime.getURL("src/index_manaba.js");
-  const [libJs, indexManabaJs] = await Promise.all([
-    import(libJsUrl),
-    import(indexManabaJsUrl),
-  ]);
-  libJs.main();
+  const [indexManabaJs] = await Promise.all([import(indexManabaJsUrl)]);
   indexManabaJs.main();
 })();

--- a/src/index_manaba.js
+++ b/src/index_manaba.js
@@ -1,4 +1,12 @@
-import { stringToHtmlElement } from "./lib.js";
+/**
+ * @param {string} s
+ * @return {Node}
+ */
+function stringToHtmlElement(s) {
+  const template = document.createElement("template");
+  template.innerHTML = s.trim();
+  return template.content.firstChild;
+}
 
 /**
  * @param {number} currentYear
@@ -19,6 +27,31 @@ function createGoToSyllabus(currentYear, courseCode, courseName) {
 }
 
 /**
+ * @param {string} pathname
+ * @returns {boolean}
+ */
+function shouldRun(pathname) {
+  const patterns = [
+    /^\/ct\/course_\d+$/,
+    /^\/ct\/course_\d+_query$/,
+    /^\/ct\/course_\d+_survey$/,
+    /^\/ct\/course_\d+_report$/,
+    /^\/ct\/course_\d+_project$/,
+    /^\/ct\/course_\d+_grade$/,
+    /^\/ct\/course_\d+_news_\d+$/,
+    /^\/ct\/page_[0-9a-f]+$/,
+  ];
+
+  for (const p of patterns) {
+    if (pathname.match(p)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * @param {string} style
  * @returns {void}
  */
@@ -29,6 +62,10 @@ function applyStyle(style) {
 }
 
 export async function main() {
+  if (!shouldRun(window.location.pathname)) {
+    return;
+  }
+
   applyStyle(`
 .go-to-syllabus {
   padding: 1em;
@@ -42,14 +79,13 @@ export async function main() {
   const currentYear = new Date().getFullYear();
   const courseCode = document.querySelector(".coursecode").innerHTML.trim();
   const courseName = document.querySelector("#coursename").innerHTML.trim();
-  const pageHeader = document.querySelector(
-    ".pageheader-course.pageheader-courseV2"
-  );
+  const pageBody = document.querySelector(".pagebody");
 
   const [goToSyllabus, _] = createGoToSyllabus(
     currentYear,
     courseCode,
     courseName
   );
-  pageHeader.insertAdjacentElement("afterend", goToSyllabus);
+  pageBody.appendChild(goToSyllabus);
+  pageBody.style.paddingBottom = "0";
 }


### PR DESCRIPTION
シラバスの
リンクの位置を
下げるのと
影響ページ
限定したよ

---

上の方にリンクを毎回生成していると、ページを開くたびにほぼページ全体が下にガタッとズレるので、それ防止としてリンクを下に入れることにした。

影響ページ：
- コーストップ
- 小テスト
- アンケート
- レポート
- プロジェクト
- 成績
- コースニュースそれぞれ
- コンテンツそれぞれ

これら以外ではシラバスへのリンクを表示しない。

<img width="977" alt="image" src="https://github.com/enpitut2023/campusTAKESHI/assets/100682393/990be29d-c170-49bd-b43c-c4dbbca913dc">
